### PR TITLE
Template update 2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Now configure it to your liking:
 <meta-data
     android:name="Substratum_Author"
     android:value="@string/ThemeAuthor"/>
+<!-- Do you support Stock and Theme Ready Gapps? -> all -->
+<!-- Do you support Theme Ready but not Stock Gapps? -> ready -->
+<!-- Do you support Stock but not Theme Ready Gapps? -> stock -->
+<meta-data
+    android:name="Substratum_ThemeReady"
+    android:value="all|ready|stock"/> <!-- Only pick one! -->
 ```
 These files link back to the strings.xml inside the res/values folder, here: 
 https://github.com/TeamSubstratum/SubstratumThemeTemplate/blob/master/app/src/main/res/values/strings.xml

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,11 +26,17 @@
         <meta-data
             android:name="Substratum_Author"
             android:value="@string/ThemeAuthor"/>
+        <!-- Do you support Stock and Theme Ready Gapps? -> all -->
+        <!-- Do you support Theme Ready but not Stock Gapps? -> ready -->
+        <!-- Do you support Stock but not Theme Ready Gapps? -> stock -->
+        <meta-data
+            android:name="Substratum_ThemeReady"
+            android:value="all|ready|stock"/> <!-- Only pick one! -->
 
         <!-- SUBSTRATUM INTERNAL USE: DO NOT TOUCH -->
         <meta-data
             android:name="Substratum_Plugin"
-            android:value="2.1.3"/>
+            android:value="2.1.4"/>
 
     </application>
 


### PR DESCRIPTION
You can now decide whether you want to enforce Theme Ready Gapps or
Stock Gapps on your theme based on your metadata.